### PR TITLE
Feature/data 2601 remove time frames from dates

### DIFF
--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -163,13 +163,13 @@ class LookMLGenerator:
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
-                        #timeframes.remove(timeframe)
+                        timeframes.remove(timeframe)
                         break
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
         tf += f"      {timeframes[-1]}\n"
         tf += "    ]"
-        return tf
+        return field_type
 
     def process_field(self, field: db.Field, parent_field_name: str = None):
         field_name = field.name

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -165,8 +165,8 @@ class LookMLGenerator:
                         timeframes.remove(timeframe)
                         break
         tf = "timeframes: [\n"
-        tf += "".join(f"      {tf},\n" for tf in self.timeframes[:-1])
-        tf += f"      {self.timeframes[-1]}\n"
+        tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
+        tf += f"      {timeframes[-1]}\n"
         tf += "    ]"
         return tf
 

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -128,8 +128,6 @@ class LookMLGenerator:
         )
         self.ignore_column_types = self.config.get_property("ignore_column_types", [])
         self.ignore_modes = self.config.get_property("ignore_modes", [])
-        self.timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
-
 
         self.time_suffixes = self.config.get_property("time_suffixes", [])
         self.order_by = self.config.get_property("order_by", "alpha")
@@ -156,21 +154,16 @@ class LookMLGenerator:
         return FIELD_TYPE_TRANSFORM[self.client.db_type].get(
             field.internal_type, ["",""]
         )    
-    
-    def _get_looker_timeframes(self, field: db.Field):
-        
+
+    def _build_timeframes(self, field_type):
         timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
 
-        if field.internal_type in ["DATE"]:            
+        if field_type in ["DATE"]:            
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
                         timeframes.remove(timeframe)
                         break
-        
-        return timeframes    
-
-    def _build_timeframes(self):
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in self.timeframes[:-1])
         tf += f"      {self.timeframes[-1]}\n"
@@ -247,7 +240,7 @@ class LookMLGenerator:
 
         # Handle time fields
         elif lookml_type == "time":
-            timeframes = self._build_timeframes()
+            timeframes = self._build_timeframes(field_type)
             # if field name ends with _at, _time, or _date
             if len(self.time_suffixes) > 0:
                 for s in self.time_suffixes:

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -15,10 +15,10 @@ FIELD_TYPE_MAPPING = {
         "NUMERIC": "number",
         "BOOLEAN": "yesno",
         "BOOL": "yesno",
-        "TIMESTAMP": "timestamp",
+        "TIMESTAMP": "time",
         "TIME": "string",
         "DATE": "time",
-        "DATETIME": "datetime",
+        "DATETIME": "time",
         "STRING": "string",
         "ARRAY": "string",
         "GEOGRAPHY": "string",
@@ -156,10 +156,10 @@ class LookMLGenerator:
         )    
 
     def _build_timeframes(self, field_type):
-
+        
         timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
 
-        if field_type in ["DATE"]:            
+        if field_type == "DATE":            
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -164,6 +164,7 @@ class LookMLGenerator:
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
+                        timeframes.remove(timeframe)
                         break
                 
         tf = "timeframes: [\n"

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -26,6 +26,17 @@ FIELD_TYPE_MAPPING = {
     }
 }
 
+TIMEFRAME_TIME_GROUP = [
+        "time",
+        "time_of_day",
+        "hour",
+        "hour_of_day",
+        "minute",
+        "second",
+        "millisecond",
+        "microsecond",
+    ]
+
 FIELD_TYPE_TRANSFORM = {
     "bigquery": {
         "TIME": ["cast(", " as string)"]
@@ -118,6 +129,8 @@ class LookMLGenerator:
         self.ignore_column_types = self.config.get_property("ignore_column_types", [])
         self.ignore_modes = self.config.get_property("ignore_modes", [])
         self.timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
+
+
         self.time_suffixes = self.config.get_property("time_suffixes", [])
         self.order_by = self.config.get_property("order_by", "alpha")
         self.capitalize_ids = self.config.get_property("capitalize_ids", True)
@@ -143,6 +156,19 @@ class LookMLGenerator:
         return FIELD_TYPE_TRANSFORM[self.client.db_type].get(
             field.internal_type, ["",""]
         )    
+    
+    def _get_looker_timeframes(self, field: db.Field):
+        
+        timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
+
+        if field.internal_type in ["DATE"]:            
+            for timeframe in timeframes:
+                for time_group in TIMEFRAME_TIME_GROUP:
+                    if timeframe.startswith(time_group):
+                        timeframes.remove(timeframe)
+                        break
+        
+        return timeframes    
 
     def _build_timeframes(self):
         tf = "timeframes: [\n"

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -158,15 +158,20 @@ class LookMLGenerator:
 
     def _build_timeframes(self, field_type):
         
-        timeframes = self.timeframes.copy()
+        timeframes = []
         
         if field_type == "DATE":            
-            for timeframe in timeframes:
+            for timeframe in self.timeframes:
+
+                time_group = False
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
-                        timeframes.remove(timeframe)
+                        time_group = True
                         break
                 
+                if not time_group:
+                    timeframes.append(timeframe)
+
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
         tf += f"      {timeframes[-1]}\n"

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -158,9 +158,10 @@ class LookMLGenerator:
 
     def _build_timeframes(self, field_type):
         
-        timeframes = []
+        timeframes = self.timeframes
         
-        if field_type == "DATE":            
+        if field_type == "DATE":    
+            timeframes = []        
             for timeframe in self.timeframes:
 
                 time_group = False
@@ -171,6 +172,7 @@ class LookMLGenerator:
                 
                 if not time_group:
                     timeframes.append(timeframe)
+        else
 
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -163,7 +163,7 @@ class LookMLGenerator:
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
-                        timeframes.remove(timeframe)
+                        #timeframes.remove(timeframe)
                         break
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -15,10 +15,10 @@ FIELD_TYPE_MAPPING = {
         "NUMERIC": "number",
         "BOOLEAN": "yesno",
         "BOOL": "yesno",
-        "TIMESTAMP": "time",
+        "TIMESTAMP": "timestamp",
         "TIME": "string",
         "DATE": "time",
-        "DATETIME": "time",
+        "DATETIME": "datetime",
         "STRING": "string",
         "ARRAY": "string",
         "GEOGRAPHY": "string",
@@ -156,6 +156,7 @@ class LookMLGenerator:
         )    
 
     def _build_timeframes(self, field_type):
+
         timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
 
         if field_type in ["DATE"]:            

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -159,7 +159,7 @@ class LookMLGenerator:
         
         timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
 
-        if field_type == "DATE":            
+        if field_type == "DATETIME":            
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
@@ -169,7 +169,7 @@ class LookMLGenerator:
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
         tf += f"      {timeframes[-1]}\n"
         tf += "    ]"
-        return field_type
+        return tf
 
     def process_field(self, field: db.Field, parent_field_name: str = None):
         field_name = field.name

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -172,7 +172,6 @@ class LookMLGenerator:
                 
                 if not time_group:
                     timeframes.append(timeframe)
-        else
 
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -158,21 +158,15 @@ class LookMLGenerator:
 
     def _build_timeframes(self, field_type):
         
-        timeframes = self.timeframes
+        timeframes = self.timeframes.copy()
         
-        if field_type == "DATE":    
-            timeframes = []        
-            for timeframe in self.timeframes:
-
-                time_group = False
+        if field_type == "DATE":            
+            for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
-                        time_group = True
+                        timeframes.remove(timeframe)
                         break
                 
-                if not time_group:
-                    timeframes.append(timeframe)
-
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
         tf += f"      {timeframes[-1]}\n"

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -160,8 +160,8 @@ class LookMLGenerator:
         
         timeframes = self.timeframes.copy()
         
-        if field_type == "DATE":            
-            for timeframe in timeframes:
+        if field_type == "DATE":      
+            for timeframe in self.timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
                         timeframes.remove(timeframe)

--- a/src/optician/lookml_generator/lookml_generator.py
+++ b/src/optician/lookml_generator/lookml_generator.py
@@ -128,6 +128,7 @@ class LookMLGenerator:
         )
         self.ignore_column_types = self.config.get_property("ignore_column_types", [])
         self.ignore_modes = self.config.get_property("ignore_modes", [])
+        self.timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
 
         self.time_suffixes = self.config.get_property("time_suffixes", [])
         self.order_by = self.config.get_property("order_by", "alpha")
@@ -157,14 +158,14 @@ class LookMLGenerator:
 
     def _build_timeframes(self, field_type):
         
-        timeframes = self.config.get_property("timeframes", DEFAULT_TIMEFRAMES)
-
-        if field_type == "DATETIME":            
+        timeframes = self.timeframes.copy()
+        
+        if field_type == "DATE":            
             for timeframe in timeframes:
                 for time_group in TIMEFRAME_TIME_GROUP:
                     if timeframe.startswith(time_group):
-                        timeframes.remove(timeframe)
                         break
+                
         tf = "timeframes: [\n"
         tf += "".join(f"      {tf},\n" for tf in timeframes[:-1])
         tf += f"      {timeframes[-1]}\n"


### PR DESCRIPTION
Exclude all 'time' timeframes from DATE fields
https://cloud.google.com/looker/docs/reference/param-field-dimension-group#time_timeframes

dynamic timeframes like 'minuteX' will also be excluded by startswith() condition 