### PR TITLE
Update project name for poetry package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 # pyproject.toml
 
-[tool.poetry]
+[project]
 name = "optician"
+
+[tool.poetry]
 version = "1.1.1"
 description = "Sync your data warehouse tables to Looker"
 authors = [


### PR DESCRIPTION
Update project name property as pip installer fails with error now:

![image](https://github.com/user-attachments/assets/1dd54eb2-1c59-4950-9dc8-94c3ac9f5127)